### PR TITLE
Allow to specify sender address for e-mails explicitly

### DIFF
--- a/monit/files/mail
+++ b/monit/files/mail
@@ -3,7 +3,7 @@ set alert {{email}} ON { invalid, timeout, resource, size, timestamp }
 {% endfor %}
 
 {%- if mail_alert.account.email and mail_alert.account.password -%}
-set mail-format { from: {{mail_alert.account.email}} }
+set mail-format { from: {{mail_alert.get('send_as', mail_alert.account.email)}} }
 {%- endif -%}
 
 {%- if mail_alert.account.server and mail_alert.account.port %}

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,7 @@ monit:
       port: 587
       email: some@example.com
       password: p@ssw0rd;)
+    send_as: Monit Daemon <monit@example.com>
     users:
       - first@example.com
       - second@example.com

--- a/pillar.example
+++ b/pillar.example
@@ -5,7 +5,7 @@ monit:
       port: 587
       email: some@example.com
       password: p@ssw0rd;)
-    send_as: Monit Daemon <monit@example.com>
+    send_as: monit@example.com
     users:
       - first@example.com
       - second@example.com


### PR DESCRIPTION
There are some cases where SMTP server username does not contain '@domain' part and this leads to crashes on monit startup. Added additional key ```send_as``` to ```monit```, which can override default settings of this formula (```monit.mail_alert.account.email```).

This should not break anything for current users, as ```monit.mail_alert.account.email``` still stays as default.