### PR TITLE
Configuration readability improvement, fix Vagrantfile and fix service watch

### DIFF
--- a/monit/config.sls
+++ b/monit/config.sls
@@ -9,9 +9,6 @@
     - mode: '0700'
     - watch_in:
       - service: {{ monit.service.name }}
-    - context:
-        config_includes: {{ monit.config_includes }}
-        http_access: {{ monit.http_access }}
 
 {#- This is the mail alert configuration #}
 {% if monit.mail_alert is defined %}
@@ -22,8 +19,6 @@
     - makedirs: True
     - watch_in:
       - service: {{ monit.service.name }}
-    - context:
-      mail_alert: {{ monit.mail_alert }}
 {% endif %}
 
 {#- This is populated by modules configuration
@@ -35,5 +30,3 @@
     - makedirs: True
     - watch_in:
       - service: {{ monit.service.name }}
-    - context:
-      modules: {{ monit.modules }}

--- a/monit/config.sls
+++ b/monit/config.sls
@@ -32,6 +32,7 @@
   file.managed:
     - source: salt://monit/files/modules
     - template: jinja
+    - makedirs: True
     - watch_in:
       - service: {{ monit.service.name }}
     - context:

--- a/monit/config.sls
+++ b/monit/config.sls
@@ -7,8 +7,10 @@
     - template: jinja
     - makedirs: True
     - mode: '0700'
+{%- if monit.service.status == 'running' %}
     - watch_in:
       - service: {{ monit.service.name }}
+{%- endif %}
 
 {#- This is the mail alert configuration #}
 {% if monit.mail_alert is defined %}
@@ -17,8 +19,10 @@
     - source: salt://monit/files/mail
     - template: jinja
     - makedirs: True
+{%- if monit.service.status == 'running' %}
     - watch_in:
       - service: {{ monit.service.name }}
+{%- endif %}
 {% endif %}
 
 {#- This is populated by modules configuration
@@ -28,5 +32,7 @@
     - source: salt://monit/files/modules
     - template: jinja
     - makedirs: True
+{%- if monit.service.status == 'running' %}
     - watch_in:
       - service: {{ monit.service.name }}
+{%- endif %}

--- a/monit/config.sls
+++ b/monit/config.sls
@@ -7,6 +7,8 @@
     - template: jinja
     - makedirs: True
     - mode: '0700'
+    - watch_in:
+      - service: {{ monit.service.name }}
     - context:
         config_includes: {{ monit.config_includes }}
         http_access: {{ monit.http_access }}
@@ -18,6 +20,8 @@
     - source: salt://monit/files/mail
     - template: jinja
     - makedirs: True
+    - watch_in:
+      - service: {{ monit.service.name }}
     - context:
       mail_alert: {{ monit.mail_alert }}
 {% endif %}
@@ -28,5 +32,7 @@
   file.managed:
     - source: salt://monit/files/modules
     - template: jinja
+    - watch_in:
+      - service: {{ monit.service.name }}
     - context:
       modules: {{ monit.modules }}

--- a/monit/defaults.yaml
+++ b/monit/defaults.yaml
@@ -6,6 +6,8 @@ monit:
   config_includes: '/etc/monit/conf.d'
   service:
     name: monit
+    enable: True
+    status: running
   daemon_interval: 10
   logfile: syslog
   http_access: 

--- a/monit/defaults.yaml
+++ b/monit/defaults.yaml
@@ -6,6 +6,8 @@ monit:
   config_includes: '/etc/monit/conf.d'
   service:
     name: monit
+  daemon_interval: 10
+  logfile: syslog
   http_access: 
     port: 2812
     bind: 127.0.0.1

--- a/monit/files/mail
+++ b/monit/files/mail
@@ -1,15 +1,16 @@
-{%- for email in mail_alert.users -%}
-set alert {{email}} ON { invalid, timeout, resource, size, timestamp }
+{%- from "monit/map.jinja" import monit with context -%}
+{%- for email in monit.mail_alert.users -%}
+set alert {{ email }} ON { invalid, timeout, resource, size, timestamp }
 {% endfor %}
 
-{%- if mail_alert.account.email -%}
-set mail-format { from: {{mail_alert.account.email}} }
+{%- if monit.mail_alert.account.email -%}
+set mail-format { from: {{ monit.mail_alert.account.email }} }
 {%- endif -%}
 
-{%- if mail_alert.account.server and mail_alert.account.port %}
-set mailserver {{mail_alert.account.server}} port {{mail_alert.account.port}} 
-    {%- if mail_alert.account.email and 'password' in mail_alert.account and mail_alert.account.password %}
-    username "{{mail_alert.account.email}}" password "{{mail_alert.account.password}}"
+{%- if monit.mail_alert.account.server and monit.mail_alert.account.port %}
+set mailserver {{ monit.mail_alert.account.server }} port {{ monit.mail_alert.account.port }} 
+    {%- if monit.mail_alert.account.email and 'password' in monit.mail_alert.account and monit.mail_alert.account.password %}
+    username "{{ monit.mail_alert.account.email }}" password "{{ monit.mail_alert.account.password }}"
     using tlsv1
     {%- endif %}
     with timeout 30 seconds

--- a/monit/files/modules
+++ b/monit/files/modules
@@ -48,8 +48,8 @@
         {%- if 'pidfile' in kind_v or 'path' in kind_v %}
 check {{ mod_name }} {{ name }} with {{ element }} {{ element_v }}
         {%- endif -%}
-      {% endfor %}
-    {% endfor %}
+      {%- endfor -%}
+    {%- endfor -%}
     {%- for kind, kind_v in mod_name_v.iteritems() -%}
       {%- for element, element_v in kind_v.iteritems() -%}
 

--- a/monit/files/modules
+++ b/monit/files/modules
@@ -1,3 +1,4 @@
+{%- from "monit/map.jinja" import monit with context -%}
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
@@ -22,7 +23,7 @@
 -#}
 {#- module = nginx_init, 
     module_v = {'process': {'with': {'pidfile':... #}
-{%- for module, module_v in modules.iteritems() -%}
+{%- for module, module_v in monit.modules.iteritems() -%}
 
   {#- mod_name = process 
       mod_name_v = {'custom': {'name': 'nginx'}, 'with': {'pidfile':... #}
@@ -46,7 +47,7 @@
     
         {#- if it has 'pidfile' or 'path' then this is the 'check' line #}
         {%- if 'pidfile' in kind_v or 'path' in kind_v %}
-check {{ mod_name|replace('\\n', '\n') }} {{ name|replace('\\n', '\n') }} with {{ element|replace('\\n', '\n') }} {{ element_v|replace('\\n', '\n') }}
+check {{ mod_name|replace('\\n', '\n') }} {{ name|replace('\\n', '\n') }} with {{ element|replace('\\n', '\n') }} "{{ element_v|replace('\\n', '\n') }}"
         {%- endif -%}
       {%- endfor -%}
     {%- endfor -%}
@@ -70,7 +71,9 @@ check {{ mod_name|replace('\\n', '\n') }} {{ name|replace('\\n', '\n') }} with {
           {#- 'action' is appended to the 'if failed' line #}
           {%- if 'action' not in element %}
   if {{ element|replace('\\n', '\n') }}
+  {%- if element_v is not none %}
     {{ element_v|replace('\\n', '\n')| indent(4) }}
+  {%- endif %}
   then {{ kind_v.action|replace('\\n', '\n') }}
           {%- endif %}
         {%- endif %}

--- a/monit/files/modules
+++ b/monit/files/modules
@@ -46,7 +46,7 @@
     
         {#- if it has 'pidfile' or 'path' then this is the 'check' line #}
         {%- if 'pidfile' in kind_v or 'path' in kind_v %}
-check {{ mod_name }} {{ name }} with {{ element }} {{ element_v }}
+check {{ mod_name|replace('\\n', '\n') }} {{ name|replace('\\n', '\n') }} with {{ element|replace('\\n', '\n') }} {{ element_v|replace('\\n', '\n') }}
         {%- endif -%}
       {%- endfor -%}
     {%- endfor -%}
@@ -58,9 +58,9 @@ check {{ mod_name }} {{ name }} with {{ element }} {{ element_v }}
 
           {#- filter 'start' to add 'program =' into this line #}
           {%- if 'start' in element or 'stop' in element %}
-  {{ element }} program = "{{ element_v }}"
+  {{ element|replace('\\n', '\n') }} program = "{{ element_v|replace('\\n', '\n') }}"
           {%- else %}
-  {{ element }} {{ element_v }}
+  {{ element|replace('\\n', '\n') }} {{ element_v|replace('\\n', '\n') }}
           {%- endif %}
         {%- endif -%}
 
@@ -69,7 +69,9 @@ check {{ mod_name }} {{ name }} with {{ element }} {{ element_v }}
 
           {#- 'action' is appended to the 'if failed' line #}
           {%- if 'action' not in element %}
-  if {{ element }} {{ element_v }} then {{ kind_v.action }}
+  if {{ element|replace('\\n', '\n') }}
+    {{ element_v|replace('\\n', '\n')| indent(4) }}
+  then {{ kind_v.action|replace('\\n', '\n') }}
           {%- endif %}
         {%- endif %}
       {%- endfor %}

--- a/monit/files/monitrc
+++ b/monit/files/monitrc
@@ -1,12 +1,14 @@
-set daemon  10
+{%- from "monit/map.jinja" import monit with context -%}
+set daemon {{ monit.daemon_interval }}
+set logfile {{ monit.logfile }}
 
-set httpd port {{ http_access.port }} and
-  use address {{ http_access.bind }}
-{%- for host in http_access.allowed.hosts %}
+set httpd port {{ monit.http_access.port }} and
+  use address {{ monit.http_access.bind }}
+{%- for host in monit.http_access.allowed.hosts %}
   allow {{ host }}
 {%- endfor %}
-{%- for userdata in http_access.allowed.users %}
+{%- for userdata in monit.http_access.allowed.users %}
   allow {{ userdata[0] }}:{{ userdata[1] }}
 {%- endfor %}
 
-include {{ config_includes }}/*
+include {{ monit.config_includes }}/*

--- a/monit/files/monitrc
+++ b/monit/files/monitrc
@@ -1,5 +1,8 @@
 {%- from "monit/map.jinja" import monit with context -%}
 set daemon {{ monit.daemon_interval }}
+{%- if monit.daemon_start_delay %}
+  with start delay {{ monit.daemon_start_delay }}
+{%- endif %}
 set logfile {{ monit.logfile }}
 
 set httpd port {{ monit.http_access.port }} and

--- a/monit/map.jinja
+++ b/monit/map.jinja
@@ -11,6 +11,10 @@ that differ from whats in defaults.yaml
 {% set os_family_map = salt['grains.filter_by']({
         'Debian': {},
         'Kali': {},
+        'FreeBSD': {
+            'config': '/usr/local/etc/monitrc',
+            'config_includes': '/usr/local/etc/monit/conf.d'
+        },
         'Gentoo': {
             'pkg': 'app-admin/monit',
             'config': '/etc/monitrc',

--- a/monit/service.sls
+++ b/monit/service.sls
@@ -4,6 +4,6 @@
 {% from "monit/map.jinja" import monit with context %}
 
 {{ monit.service.name }}:
-  service.running:
-    - enable: True
+  service.{{ monit.service.status }}:
+    - enable: {{ monit.service.enable }}
     - restart: True

--- a/monit/service.sls
+++ b/monit/service.sls
@@ -7,7 +7,3 @@
   service.running:
     - enable: True
     - restart: True
-    - watch:
-      - file: {{ monit.config }}
-      - file: {{ monit.config_includes }}/mail
-      - file: {{ monit.config_includes }}/modules

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,7 @@
 monit: 
+  service:
+    enable: True
+    status: running
   mail_alert:
     account:
       server: smtp.gmail.com

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@ monit:
   service:
     enable: True
     status: running
+  daemon_interval: 30
+  daemon_start_delay: 60
   mail_alert:
     account:
       server: smtp.gmail.com


### PR DESCRIPTION
Hey guys,

This PR address the following things:

1. Improve configuration readability, before this PR with the `pillar.example` the configuration looked like:

```
# -*- coding: utf-8 -*-
# vim: ft=jinja
    
    
check process nginx with pidfile /var/run/nginx.pid
    
    
    
  group www
  start program = "/etc/init.d/nginx start"
  stop program = "/etc/init.d/nginx stop"
  if failed host 127.0.0.1 port 80 protocol http then restart
  
check process postfix with pidfile /var/spool/postfix/pid/master.pid
    
    
    
  group mail
  start program = "/etc/init.d/postfix start"
  stop program = "/etc/init.d/postfix stop"
  if failed port 25 protocol smtp then restart
  
check process cron with pidfile /var/run/cron.pid
    
    
  group system
  start program = "/etc/init.d/cron start"
  stop program = "/etc/init.d/cron stop"
  depends on cron_rc
  
    
    
check file cron_rc with path /etc/init.d/cron
    
    
    
    
    
  if failed checksum then unmonitor
  if failed permission 755 then unmonitor
  if failed uid root then unmonitor
  if failed gid root then unmonitor
  
check process gdm with pidfile /var/run/gdm.pid
    
    
  start program = "/etc/init.d/gdm start"
  stop program = "/etc/init.d/gdm stop"
  
```

Now it looks like:

```
# -*- coding: utf-8 -*-
# vim: ft=jinja
    
check process nginx with pidfile /var/run/nginx.pid
  group www
  start program = "/etc/init.d/nginx start"
  stop program = "/etc/init.d/nginx stop"
  if failed
    host 127.0.0.1 port 80 protocol http
  then restart
  
check process postfix with pidfile /var/spool/postfix/pid/master.pid
  group mail
  start program = "/etc/init.d/postfix start"
  stop program = "/etc/init.d/postfix stop"
  if failed
    port 25 protocol smtp
  then restart
  
check process cron with pidfile /var/run/cron.pid
  group system
  start program = "/etc/init.d/cron start"
  stop program = "/etc/init.d/cron stop"
  depends on cron_rc
  
    
check file cron_rc with path /etc/init.d/cron
  if failed
    checksum
  then unmonitor
  if failed
    permission 755
  then unmonitor
  if failed
    uid root
  then unmonitor
  if failed
    gid root
  then unmonitor
  
check process gdm with pidfile /var/run/gdm.pid
  start program = "/etc/init.d/gdm start"
  stop program = "/etc/init.d/gdm stop"
```

2. Fix Vagrantfile to work and also allow to change `pillar.example` in the host and have it available in the VM. Additionally I used `linked_clone` to improve tear down/creation times.

3. When the pillar don't include `mail_alert` setting the service failed to start due to the `watch` statement, so I did the other way around by using `watch_in`.

4. Add support for FreeBSD.

5. Allow to change other Monit settings like daemon interval or syslog. Also instead of passing the context to template files I import the map directly.

6. Allow to configure the service status (In my use case I need the service to be enabled but not running).

Thanks!